### PR TITLE
fix: Run `goimports -w .` to fix Lint Errors

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/labstack/echo/v4"
 )
 
 func Handle(c echo.Context) error {

--- a/service/api.go
+++ b/service/api.go
@@ -1,10 +1,11 @@
 package service
 
 import (
-	"github.com/labstack/echo/v4"
 	"haproxy/handler"
 	"log"
 	"os"
+
+	"github.com/labstack/echo/v4"
 )
 
 func Run() {


### PR DESCRIPTION
As you can these tools must be run on your project every time you change a file.

```
goimports
gofmt
...
```
One way to achieve this is by using the `watcher` feature of Goland.